### PR TITLE
Replace deprecated BlobBuilder with Blob

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -124,9 +124,8 @@ function openPage() {
         ia[i] = byteString.charCodeAt(i);
     }
 
-    // write the ArrayBuffer to a blob, and you're done
-    var bb = new window.WebKitBlobBuilder();
-    bb.append(ab);
+    // create a blob for writing to a file
+    var blob = new Blob([ab], {type: mimeString});
 
     // come up with a filename
     var name = contentURL.split('?')[0].split('#')[0];


### PR DESCRIPTION
The Blob is dead! Long live the Blob.

Chrome 24 got rid of BlobBuilder so you need to switch to a Blob. [More info here](http://updates.html5rocks.com/2012/06/Don-t-Build-Blobs-Construct-Them).
