### PR TITLE
Use the built-in Chrome API callback to let the popup JS know when the capture is finished

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Full Page Screen Capture",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "manifest_version": 2,
   "description": "Screen capture your current page in entirety and reliably!",
   "browser_action": {

--- a/page.js
+++ b/page.js
@@ -1,7 +1,10 @@
 
 function onMessage(request, sender, callback) {
-    if (request.msg == 'scrollPage') {
+    if (request.msg === 'scrollPage') {
         getPositions(callback);
+    }
+    else {
+        console.error('Unknown message received from background: ' + request.msg);
     }
 }
 
@@ -10,7 +13,7 @@ if (!window.hasScreenCapturePage) {
     chrome.extension.onRequest.addListener(onMessage);
 }
 
-function getPositions(cb) {
+function getPositions(callback) {
     var body = document.body,
         fullWidth = document.width,
         fullHeight = document.height,
@@ -54,9 +57,7 @@ function getPositions(cb) {
     (function scrollTo() {
         if (!arrangements.length) {
             window.scrollTo(0, 0);
-            chrome.extension.sendRequest({msg: 'openPage'}, function(response) {
-            });
-            return cb && cb();
+            return callback();
         }
 
         var next = arrangements.shift(),
@@ -68,8 +69,6 @@ function getPositions(cb) {
             msg: 'capturePage',
             x: window.scrollX,
             y: window.scrollY,
-            width: windowWidth,
-            height: windowHeight,
             complete: (numArrangements-arrangements.length)/numArrangements,
             totalWidth: fullWidth,
             totalHeight: fullHeight

--- a/popup.js
+++ b/popup.js
@@ -67,14 +67,19 @@ var screenshot, contentURL = '';
 function sendScrollMessage(tab) {
     contentURL = tab.url;
     screenshot = {};
-    chrome.tabs.sendRequest(tab.id, {msg: 'scrollPage'}, function(response) {});
+    chrome.tabs.sendRequest(tab.id, {msg: 'scrollPage'}, function() {
+        // We're done taking snapshots of all parts of the window. Display
+        // the resulting full screenshot image in a new browser tab.
+        displayPage();
+    });
 }
 
 chrome.extension.onRequest.addListener(function(request, sender, callback) {
-    var fn = {'capturePage': capturePage,
-              'openPage': openPage}[request.msg];
-    if (fn) {
-        fn(request, sender, callback);
+    if (request.msg === 'capturePage') {
+        capturePage(request, sender, callback);
+    }
+    else {
+        console.error('Unknown message received from content script: ' + request.msg);
     }
 });
 
@@ -105,7 +110,7 @@ function capturePage(data, sender, callback) {
         });
 }
 
-function openPage() {
+function displayPage() {
     // standard dataURI can be too big, let's blob instead
     // http://code.google.com/p/chromium/issues/detail?id=69227#c27
 


### PR DESCRIPTION
Use the provided callback to tell the popup JS when the full capture has completed instead of passing a message.

Also: Removed a couple of unused attributes from the page script message to the popup JS. Changed openPage to displayPage.

There's no real need to accept these changes, I'm just learning about the code, etc., so they're just suggestions.
