### PR TITLE
Removed apparently unused variables in page.js

### DIFF
--- a/page.js
+++ b/page.js
@@ -24,12 +24,7 @@ function getPositions(cb) {
         xDelta = windowWidth,
         yPos = fullHeight - yDelta + 1,
         xPos,
-        numArrangements,
-        canvas = document.createElement('canvas'),
-        ctx;
-    canvas.width = fullWidth;
-    canvas.height = fullHeight;
-    ctx = canvas.getContext('2d');
+        numArrangements;
 
     while (yPos > -yDelta) {
         xPos = 0;


### PR DESCRIPTION
The `canvas` and `ctx` variables in page.js do not appear to be used.
