### PR TITLE
Removed an unneeded window.scroll call from the cleanup function.

### DIFF
--- a/page.js
+++ b/page.js
@@ -63,7 +63,6 @@ function getPositions(callback) {
     (function processArrangements() {
         if (!arrangements.length) {
             cleanUp();
-            window.scrollTo(0, 0);
             if (callback) {
                 callback();
             }


### PR DESCRIPTION
There was an extra (old) `window.scroll(0, 0)` call that needed removing (invoked after the cleanup function had restored the scroll position).
