### PR TITLE
Use the activeTab permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   },
-  "permissions": [ "tabs", "http://*/*", "https://*/*", "notifications" ],
+  "permissions": [ "activeTab" ],
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
It seems sufficient to use the activeTab permission only, making installation less concerning from a privacy POV.

See http://developer.chrome.com/extensions/activeTab.html
