### PR TITLE
Scale the canvas context to account for device pixel ratios that are not 1

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -94,6 +94,11 @@ function capturePage(data, sender, callback) {
         canvas.height = data.totalHeight;
         screenshot.canvas = canvas;
         screenshot.ctx = canvas.getContext('2d');
+        // Scale to account for device pixel ratios greater than one. (On a
+        // MacBook Pro with Retina display, window.devicePixelRatio = 2.)
+        if (window.devicePixelRatio !== 1){
+            screenshot.ctx.scale(1 / window.devicePixelRatio, 1 / window.devicePixelRatio);
+        }
     }
 
     chrome.tabs.captureVisibleTab(


### PR DESCRIPTION
The value of `window.devicePixelRatio` on a MacBook Pro with Retina display is 2 (it's 1 on my Thunderbolt display). This causes the PNG screenshot to only show half the full page, unless we scale the canvas.

This may not be a complete solution, but it's a definite improvement on the sites I've tried. See http://outof.me/chrome-extension-retina-capturevisibletab-translate3d-2-x-res/ for discussion of possibly needing to add (& later remove) a `transform: translate3d(0,0,0)` styled div to the DOM under other circumstances. I'm not sure if that would work or how disruptive it would be to the user, but at least this ticket solves what looks to be the majority case.
