### PR TITLE
Add keyboard shortcut to trigger full-screen snapshotting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,14 @@
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F",
+        "mac": "MacCtrl+Shift+F"
+      }
+    }
+  },
   "permissions": [ "activeTab" ],
   "icons": {
     "16": "icon16.png",


### PR DESCRIPTION
Prior to this commit, the full page screen capture extension had no
extension specified hotkey to trigger a full page screen capture.

Now, we’ve specified to use “ctrl+shift+F” (“F” for “full screen”, or
“fun”) to launch the browser action.

Note that existing users will need to remove and re-load the extension
for this to take place, otherwise they need to go to the extensions tab
and set the keyboard shortcuts for themselves.