### PR TITLE
Replace deprecated API

### DIFF
--- a/page.js
+++ b/page.js
@@ -1,19 +1,20 @@
 
 var CAPTURE_DELAY = 150;
 
-function onMessage(request, sender, callback) {
-    if (request.msg === 'scrollPage') {
+function onMessage(data, sender, callback) {
+    if (data.msg === 'scrollPage') {
         getPositions(callback);
-    } else if (request.msg == 'logMessage') {
-        console.log('[POPUP LOG]', request.data);
+        return true;
+    } else if (data.msg == 'logMessage') {
+        console.log('[POPUP LOG]', data.data);
     } else {
-        console.error('Unknown message received from background: ' + request.msg);
+        console.error('Unknown message received from background: ' + data.msg);
     }
 }
 
 if (!window.hasScreenCapturePage) {
     window.hasScreenCapturePage = true;
-    chrome.extension.onRequest.addListener(onMessage);
+    chrome.runtime.onMessage.addListener(onMessage);
 }
 
 function max(nums) {
@@ -116,7 +117,7 @@ function getPositions(callback) {
             // In case the below callback never returns, cleanup
             var cleanUpTimeout = window.setTimeout(cleanUp, 1250);
 
-            chrome.extension.sendRequest(data, function(captured) {
+            chrome.runtime.sendMessage(data, function(captured) {
                 window.clearTimeout(cleanUpTimeout);
                 if (captured) {
                     // Move on to capture next arrangement.

--- a/popup.js
+++ b/popup.js
@@ -67,7 +67,7 @@ var screenshot, contentURL = '';
 function sendScrollMessage(tab) {
     contentURL = tab.url;
     screenshot = {};
-    chrome.tabs.sendRequest(tab.id, {msg: 'scrollPage'}, function() {
+    chrome.tabs.sendMessage(tab.id, {msg: 'scrollPage'}, function() {
         // We're done taking snapshots of all parts of the window. Display
         // the resulting full screenshot image in a new browser tab.
         openPage();
@@ -75,14 +75,15 @@ function sendScrollMessage(tab) {
 }
 
 function sendLogMessage(data) {
-    chrome.tabs.getSelected(null, function(tab) {
-        chrome.tabs.sendRequest(tab.id, {msg: 'logMessage', data: data}, function() {});
+    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {msg: 'logMessage', data: data}, function() {});
     });
 }
 
-chrome.extension.onRequest.addListener(function(request, sender, callback) {
+chrome.runtime.onMessage.addListener(function(request, sender, callback) {
     if (request.msg === 'capturePage') {
         capturePage(request, sender, callback);
+        return true;
     } else {
         console.error('Unknown message received from content script: ' + request.msg);
     }
@@ -208,8 +209,8 @@ function openPage() {
 // start doing stuff immediately! - including error cases
 //
 
-chrome.tabs.getSelected(null, function(tab) {
-
+chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+    var tab = tabs[0];
     if (testURLMatches(tab.url)) {
         var loaded = false;
 


### PR DESCRIPTION
The plugin used deprecated methods :

`sendRequest` and `onRequest` are replaced by `sendMessage` and `onMessage`
there is a small change with the message api : it doesn't allow asynchronous callback by default. The onMessage handler must return true to allow this.

`tabs.getSelected` replaced by `tabs.query`



The plugin still works the same ways on Chrome, but this will allow to run it on Firefox, where deprecated methods are not supported at all.

The `captureVisibleTab` is not yet available on Firefox, so it isn't possible to port the plugin today