### PR TITLE
Adding keyboard shortcut option

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,10 +16,10 @@
    "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "windows": "Ctrl+Shift+Y",
-        "mac": "Command+Shift+Y",
-        "chromeos": "Ctrl+Shift+U",
-        "linux": "Ctrl+Shift+J"
+        "windows": "Ctrl+D",
+        "mac": "Command+D",
+        "chromeos": "Ctrl+D",
+        "linux": "Ctrl+D"
       }
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,15 @@
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
+  },
+   "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "windows": "Ctrl+Shift+Y",
+        "mac": "Command+Shift+Y",
+        "chromeos": "Ctrl+Shift+U",
+        "linux": "Ctrl+Shift+J"
+      }
+    }
   }
 }


### PR DESCRIPTION
Keyboard shortcut can be set in the extensions manager, allowing the triggering of the screenshot based on a hotkey instead of clicking the icon.