### PR TITLE
fix: This value is ignored for PNG images

### DIFF
--- a/api.js
+++ b/api.js
@@ -44,7 +44,7 @@ window.CaptureAPI = (function() {
 
     function capture(data, screenshots, sendResponse, splitnotifier) {
         chrome.tabs.captureVisibleTab(
-            null, {format: 'png', quality: 100}, function(dataURI) {
+            null, {format: 'png'}, function(dataURI) {
                 if (dataURI) {
                     var image = new Image();
                     image.onload = function() {


### PR DESCRIPTION
https://developer.chrome.com/extensions/tabs#method-captureVisibleTab
According to the document, it is unnecessary in this case.