### PR TITLE
changed CAPTURE_DELAY from 150 to 600

### DIFF
--- a/page.js
+++ b/page.js
@@ -1,5 +1,5 @@
 
-var CAPTURE_DELAY = 150;
+var CAPTURE_DELAY = 600;
 
 function onMessage(data, sender, callback) {
     if (data.msg === 'scrollPage') {


### PR DESCRIPTION
As described on issue #104 

Since version 92, we are only allowed to capture the screen twice every second. Changing the delay to 600 seems to be the safest value.